### PR TITLE
Build with GHA's Ubuntu 20.04

### DIFF
--- a/.github/workflows/build_and_upload_artifacts.yaml
+++ b/.github/workflows/build_and_upload_artifacts.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - vi/pin-build-envs
   push:
     branches:
       - main
@@ -17,19 +18,19 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest-xlarge]
+        os: [ubuntu-20.04]
 
     steps:
       - uses: actions/checkout@v4
 
       - name: Install ninja
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-20.04'
         run: |
           sudo apt update
           sudo apt-get -y install ninja-build
 
       - name: Install ninja
-        if: matrix.os == 'macos-latest-xlarge'
+        if: matrix.os == 'macos-12-xlarge'
         run: |
           brew install ninja
 
@@ -49,9 +50,3 @@ jobs:
 
       - name: Build Toolchain
         run: ./package.sh
-
-      - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: "${{ env.ARTIFACT_NAME }}"
-          path: "${{ env.ARTIFACT_NAME }}.tar.zst"

--- a/.github/workflows/build_and_upload_artifacts.yaml
+++ b/.github/workflows/build_and_upload_artifacts.yaml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - main
-      - vi/pin-build-envs
   push:
     branches:
       - main
@@ -18,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-20.04, macos-12-xlarge]
 
     steps:
       - uses: actions/checkout@v4
@@ -50,3 +49,9 @@ jobs:
 
       - name: Build Toolchain
         run: ./package.sh
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: "${{ env.ARTIFACT_NAME }}"
+          path: "${{ env.ARTIFACT_NAME }}.tar.zst"

--- a/README.md
+++ b/README.md
@@ -9,3 +9,12 @@ This repository compile and publish as release final binaries of the Rust toolch
 tar --zstd -xf rust-rve-nightly-2023-04-05-aarch64-apple-darwin.tar.zst
 mv rve-nightly ~/.rustup/toolchains/
 ```
+
+## Build with `ci-unified`
+
+If there is a need to build the toolchain using [Parity default CI environment](https://github.com/paritytech/scripts/tree/master/dockerfiles/ci-unified), tweak the build step as follows:
+
+```
+export CXX=/usr/bin/clang++-15
+./build.sh --DCMAKE_BUILD_TYPE=Release
+```


### PR DESCRIPTION
Build the toolchain with GHA's natively supported Ubuntu 20.04 as 20.04 has the same glibc version (2.31) as Debian 11 that is used as the base distro for our `ci-unified`.
Also pin macOS GHA runner to Monterey (as latest GHA macOS offering currently points to Monterey).