### PR TITLE
Keep `macos-latest-xlarge` only

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-12-xl, macos-latest-xlarge]
+        os: [ubuntu-20.04, macos-latest-xlarge]
 
     steps:
       - name: Free Disk Space (Ubuntu)

--- a/.github/workflows/build_and_upload_artifacts.yaml
+++ b/.github/workflows/build_and_upload_artifacts.yaml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-12-xl, macos-latest-xlarge]
+        os: [ubuntu-20.04, macos-latest-xlarge]
 
     steps:
       - name: Free Disk Space (Ubuntu)


### PR DESCRIPTION
`macos-12-xl` is `x86_64` and we don't need it.